### PR TITLE
chore(release): bump version to 0.4.4

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ogi"
-version = "0.4.3"
+version = "0.4.4"
 description = "OpenGraph Intel — open source link analysis and OSINT framework"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -905,7 +905,7 @@ wheels = [
 
 [[package]]
 name = "ogi"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release preparation PR.

- Bumps `backend/pyproject.toml` version
- Refreshes `backend/uv.lock`
- Bumps `frontend/package.json` version

Merge this PR into `main`, then run **Cut Release** with version `0.4.4`.